### PR TITLE
Added option for custom language extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,12 @@ CLI Options:
 ```
 mExport - minimize export list of haskell modules
 
-Usage: mexport [--version | [--path DIR] [--analyze]]
+Usage: mexport [--version | [--path DIR] [--analyze] [--extensions GHCEXT]]
 
 Available options:
   --version                Print the version
   --path DIR               Path of Haskell project (default: ".")
   --analyze                Analyze the Haskell project
+  --extensions GHCEXT      Comma separated GHC Language extensions
   -h,--help                Show this help text
 ```

--- a/lib/MExport/Config.hs
+++ b/lib/MExport/Config.hs
@@ -12,6 +12,7 @@ data Config =
     , singleListExport :: Bool
     , projectPath :: String
     , excludeDir :: [String]
+    , extensions :: [String]
     }
 
 getConfig :: Config
@@ -22,4 +23,5 @@ getConfig =
     , singleListExport = False
     , projectPath = "."
     , excludeDir = [".stack-work", ".git"]
+    , extensions = []
     }

--- a/package.yaml
+++ b/package.yaml
@@ -41,6 +41,7 @@ executables:
       - base
       - mExport
       - optparse-applicative
+      - text
 
 tests:
   mexport-test:


### PR DESCRIPTION
Changes:
- Added option `--extensions` to provide GHC Language extensions from CLI.
- Removed the hard coded extensions from code

List of supported extensions: [Link](https://www.stackage.org/haddock/lts-18.23/ghc-lib-parser-8.10.7.20210828/GHC-LanguageExtensions-Type.html#t:Extension)

Example Usage:
```
mexport --extensions BangPatterns,TypeApplications
```