### PR TITLE
Adds support to read config from yaml file

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,10 @@ For cli options run `mexport --help`
 
 CLI Options:
 ```shell
-mExport - minimize export list of haskell modules
+mExport 0.0.1 - minimize export list of haskell modules
 
-Usage: mexport [--version | [--path DIR] [--analyze] [--extensions GHCEXT] [--dump-dir DIR] [--indent NUM] [--collapse NUM]]
+Usage: mexport [--version | [--path DIR] [--analyze] [--extensions GHCEXT] 
+                 [--dump-dir DIR] [--indent NUM] [--collapse NUM]]
 
 Available options:
   --version                Print the version
@@ -69,8 +70,20 @@ Available options:
                            project can be parsed
   --extensions GHCEXT      Comma separated GHC Language extensions
   --dump-dir DIR           GHC dump directory path
-  --indent NUM             Indentation for the exports (default: 2)
+  --indent NUM             Indentation for the exports
   --collapse NUM           Exports everything of a type if NUM or more
-                           percentage is exported (default: 100)
+                           percentage is exported
   -h,--help                Show this help text
+```
+
+You can also provide some options using a yaml configuration file
+
+Create a `.mexport.yaml` inside the project directory, `mExport` will detect the file itself
+```yaml
+indent: 2
+collapse: 80
+dump-dir: /foo/bar
+extensions:
+  - BangPatterns
+  - TypeApplications
 ```

--- a/lib/MExport/Config.hs
+++ b/lib/MExport/Config.hs
@@ -5,6 +5,7 @@ data CodeStyle =
     { indent :: Int
     , collapseAfter :: Int
     }
+  deriving (Show)
 
 data Config =
   Config
@@ -16,9 +17,10 @@ data Config =
     , extensions :: [String]
     , dumpDir :: Maybe String
     }
+  deriving (Show)
 
-getConfig :: Config
-getConfig =
+defaultConfig :: Config
+defaultConfig =
   Config
     { codeStyle = CodeStyle {indent = 2, collapseAfter = 100}
     , writeOnFile = True

--- a/package.yaml
+++ b/package.yaml
@@ -7,12 +7,13 @@ default-extensions:
   - DeriveFunctor
   - DeriveGeneric
   - DuplicateRecordFields
+  - FlexibleContexts
   - LambdaCase
   - OverloadedStrings
-  - TypeApplications
+  - RecordWildCards
   - TemplateHaskell
+  - TypeApplications
   - ViewPatterns
-  - FlexibleContexts
 
 ghc-options:
   - -O2
@@ -40,9 +41,12 @@ executables:
     source-dirs: src
     dependencies:
       - base
+      - directory
+      - filepath
       - mExport
       - optparse-applicative
       - text
+      - yaml
 
 tests:
   mexport-test:

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -6,12 +6,14 @@ import Prelude
 import qualified MExport as ME
 import qualified MExport.Config as CC
 
-import qualified Types as T (Action(..))
+import qualified Types as T
 import qualified Utils as U
 
 main :: IO ()
 main = do
-  action <- U.getAction CC.getConfig
+  action <- U.getAction
   case action of
-    T.ShowVersion -> putStrLn "mExport version 0.0.1"
-    T.Run config -> void $ ME.mExport config
+    T.ShowVersion -> putStrLn $ "mExport v" <> U.version
+    T.Run args -> do
+      config <- U.mkConfig CC.defaultConfig args
+      void $ ME.mExport config

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -1,7 +1,39 @@
 module Types where
 
-import qualified MExport.Config as CC (Config)
+import qualified Data.Maybe as DM
+import qualified Data.Yaml as Y
+
+import qualified MExport.Config as MC
 
 data Action
   = ShowVersion
-  | Run CC.Config
+  | Run MExportArgs
+
+data MExportConfig =
+  MExportConfig
+    { indent :: Int
+    , collapse :: Int
+    , extensions :: [String]
+    , dumpDir :: Maybe String
+    }
+  deriving (Show)
+
+instance Y.FromJSON MExportConfig where
+  parseJSON (Y.Object v) =
+    let defaultCodeStyle = MC.codeStyle MC.defaultConfig
+     in MExportConfig <$> fmap (DM.fromMaybe (MC.indent defaultCodeStyle)) (v Y..:? "indent") <*>
+        fmap (DM.fromMaybe (MC.collapseAfter defaultCodeStyle)) (v Y..:? "collapse") <*>
+        fmap (DM.fromMaybe $ MC.extensions MC.defaultConfig) (v Y..:? "extensions") <*>
+        fmap (DM.fromMaybe (MC.dumpDir MC.defaultConfig)) (v Y..:? "dump-dir")
+  parseJSON _ = fail "Expected Object for Config value"
+
+data MExportArgs =
+  MExportArgs
+    { projectPathArg :: String
+    , analyseArg :: Bool
+    , extensionsArg :: Maybe [String]
+    , dumpDirArg :: Maybe String
+    , indentArg :: Maybe Int
+    , collapseArg :: Maybe Int
+    }
+  deriving (Show)

--- a/src/Utils.hs
+++ b/src/Utils.hs
@@ -1,41 +1,110 @@
 module Utils
   ( getAction
+  , mkConfig
+  , version
   ) where
 
 import Options.Applicative
 import Prelude
 
+import qualified Data.Maybe as DM
 import qualified Data.Text as DT
+import qualified Data.Version as DV
+import qualified Data.Yaml as Y
+import qualified System.Directory as SD
+import qualified System.FilePath as SF
 
-import qualified MExport.Config as CC
+import qualified MExport.Config as MC
+import qualified MExport.Utils.Utils as MU
 import qualified Types as T
 
-getAction :: CC.Config -> IO T.Action
-getAction config =
-  execParser (info (options config <**> helper) (header "mExport - minimize export list of haskell modules"))
+import qualified Paths_mExport as PM (version)
 
-options :: CC.Config -> Parser T.Action
-options config =
+getAction :: IO T.Action
+getAction =
+  execParser (info (options <**> helper) (header ("mExport " <> version <> " - minimize export list of haskell modules")))
+
+options :: Parser T.Action
+options =
   flag' T.ShowVersion (long "version" <> help "Print the version") <|>
-  T.Run <$> (mkConfig <$> projectPath <*> analyze <*> customExtensions <*> dumpDir <*> indent <*> collapse)
+  T.Run <$> (mkArgs <$> projectPath <*> analyze <*> customExtensions <*> dumpDir <*> indent <*> collapse)
   where
     projectPath = strOption (long "path" <> help "Path of Haskell project" <> showDefault <> value "." <> metavar "DIR")
     analyze = switch (long "analyze" <> help "Analyze the Haskell project, helps in verifying if project can be parsed")
     customExtensions =
-      strOption (long "extensions" <> help "Comma separated GHC Language extensions" <> value [] <> metavar "GHCEXT")
+      optional $ strOption (long "extensions" <> help "Comma separated GHC Language extensions" <> metavar "GHCEXT")
     mkExtensions strExts = DT.unpack <$> (DT.splitOn "," $ DT.pack strExts)
-    indent = option auto (long "indent" <> help "Indentation for the exports" <> showDefault <> value 2 <> metavar "NUM")
+    indent = optional $ option auto (long "indent" <> help "Indentation for the exports" <> metavar "NUM")
     collapse =
+      optional $
       option
         auto
-        (long "collapse" <>
-         help "Exports everything of a type if NUM or more percentage is exported" <> showDefault <> value 100 <> metavar "NUM")
+        (long "collapse" <> help "Exports everything of a type if NUM or more percentage is exported" <> metavar "NUM")
     dumpDir = optional $ strOption (long "dump-dir" <> help "GHC dump directory path" <> metavar "DIR")
-    mkConfig path _analyze extensions _dumpDir _indent _collapse =
-      config
-        { CC.projectPath = path
-        , CC.writeOnFile = not _analyze
-        , CC.extensions = mkExtensions extensions
-        , CC.dumpDir = _dumpDir
-        , CC.codeStyle = CC.CodeStyle {CC.indent = _indent, CC.collapseAfter = _collapse}
+    mkArgs path _analyze extensions _dumpDir _indent _collapse =
+      T.MExportArgs
+        { T.projectPathArg = path
+        , T.analyseArg = _analyze
+        , T.extensionsArg = mkExtensions <$> extensions
+        , T.dumpDirArg = _dumpDir
+        , T.indentArg = _indent
+        , T.collapseArg = _collapse
         }
+
+mkConfig :: MC.Config -> T.MExportArgs -> IO MC.Config
+mkConfig defaultConfig T.MExportArgs {..} = do
+  updatedConfig <- getConfigFromYaml defaultConfig projectPathArg
+  let updatedCodeStyle = MC.codeStyle updatedConfig
+  return $
+    updatedConfig
+      { MC.projectPath = projectPathArg
+      , MC.writeOnFile = not analyseArg
+      , MC.extensions = DM.fromMaybe (MC.extensions updatedConfig) extensionsArg
+      , MC.dumpDir = dumpDirArg <|> (MC.dumpDir updatedConfig)
+      , MC.codeStyle =
+          MC.CodeStyle
+            { MC.indent = DM.fromMaybe (MC.indent updatedCodeStyle) indentArg
+            , MC.collapseAfter = DM.fromMaybe (MC.collapseAfter updatedCodeStyle) collapseArg
+            }
+      }
+
+getConfigFromYaml :: MC.Config -> String -> IO MC.Config
+getConfigFromYaml defaultConfig path = do
+  homeDir <- SD.getHomeDirectory
+  maybeConfig <- findConfigFile homeDir =<< SD.makeAbsolute path
+  case maybeConfig of
+    Nothing -> return defaultConfig
+    Just file -> do
+      result <- Y.decodeFileEither file
+      case result of
+        Left e -> error (show e)
+        Right config -> applyConfig file config
+  where
+    findConfigFile :: String -> String -> IO (Maybe String)
+    findConfigFile homeDir curDir = do
+      if homeDir /= curDir
+        then do
+          maybeConfig <- return . MU.headMaybe . filter (== ".mexport.yaml") =<< SD.listDirectory curDir
+          case maybeConfig of
+            Just configFile -> return $ Just $ curDir SF.</> configFile
+            Nothing -> findConfigFile homeDir $ SF.takeDirectory curDir
+        else return Nothing
+    applyConfig :: String -> T.MExportConfig -> IO MC.Config
+    applyConfig (SF.takeDirectory -> configDir) T.MExportConfig {..} = do
+      let defaultCodeStyle = MC.codeStyle defaultConfig
+          abDumpDir =
+            case dumpDir of
+              Just dir ->
+                if SF.isAbsolute dir
+                  then Just dir
+                  else Just $ SF.normalise $ configDir SF.</> dir
+              Nothing -> Nothing
+      return $
+        defaultConfig
+          { MC.codeStyle = defaultCodeStyle {MC.indent = indent, MC.collapseAfter = collapse}
+          , MC.extensions = extensions
+          , MC.dumpDir = abDumpDir
+          }
+
+version :: String
+version = DV.showVersion PM.version

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -9,7 +9,7 @@ import Test.Hspec
 import qualified Text.Pretty.Simple as PS (pPrintNoColor)
 
 import qualified MExport as ME (mExport)
-import qualified MExport.Config as CC (Config(..), getConfig)
+import qualified MExport.Config as CC (Config(..), defaultConfig)
 import qualified MExport.Types as MT
 
 main :: IO ()
@@ -22,7 +22,7 @@ main = do
 
 test :: IO (MT.Project MT.PrettyModule)
 test = do
-  let config = CC.getConfig {CC.writeOnFile = False, CC.singleListExport = True, CC.projectPath = "./test/sample"}
+  let config = CC.defaultConfig {CC.writeOnFile = False, CC.singleListExport = True, CC.projectPath = "./test/sample"}
   exportMap <- ME.mExport config
   return exportMap
 

--- a/test/sample/.mexport.yaml
+++ b/test/sample/.mexport.yaml
@@ -1,0 +1,2 @@
+dump-dir: ./.stack-work/dist/x86_64-osx/Cabal-3.0.1.0/build/test-sample/test-sample-tmp
+collapse: 80


### PR DESCRIPTION
Feature: Add support to read config file `.mexport.yaml`

The yaml file `.mexport.yaml` supports the below cli options:
```yaml
- indent
- collapse
- extensions
- dump-dir
```
Sample `.mexport.yaml`
```yaml
indent: 2
collapse: 80
dump-dir: /foo/bar
extensions:
  - BangPatterns
  - TypeApplications
```

mExport will use the provided project path (default: current working directory) to search for `.mexport.yaml`.
It will lookup all parent directories for configuration file.

CLI option overrides the provided configuration in yaml file.